### PR TITLE
Update requests_csv.py

### DIFF
--- a/zipline/sources/requests_csv.py
+++ b/zipline/sources/requests_csv.py
@@ -563,6 +563,19 @@ class PandasRequestsCSV(PandasCSV):
             if content_length > self.MAX_DOCUMENT_SIZE:
                 raise Exception('Document size too big.')
             if chunk:
+                if isinstance(chunk, bytes):
+                    if content_length == 0:
+                        import codecs
+                        if chunk[:3] == codecs.BOM_UTF8:
+                            encoding = 'utf-8-sig'
+                        elif chunk[:2] == codecs.BOM_UTF16_LE or chunk[:2] == codecs.BOM_UTF16_BE:
+                            encoding = 'utf-16'
+                        elif chunk[:4] == codecs.BOM_UTF32_LE or chunk[:4] == codecs.BOM_UTF32_BE:
+                            encoding = 'utf-32'
+                        else:
+                            encoding = 'utf-8'
+                        decoder = codecs.getincrementaldecoder(encoding)(errors='replace')
+                    chunk = decoder.decode(chunk)
                 content_length += len(chunk)
                 yield chunk
 


### PR DESCRIPTION
When there is no Header (as some of the files of CBOE) this function will crash your algo when reading a headerless csv file. Although it's a known problem in Requests it's not solved for years so we need to patch this file here. See also description in ref: https://github.com/quantopian/zipline/issues/1837)