### PR TITLE
(ib-broker) fix empty ohlcv-values

### DIFF
--- a/zipline/gens/brokers/ib_broker.py
+++ b/zipline/gens/brokers/ib_broker.py
@@ -1022,7 +1022,7 @@ class IBBroker(Broker):
             ohlcv['volume'] = trade_sizes.resample(resample_freq).sum()
 
             # Add asset as level 0 column; ohlcv will be used as level 1 cols
-            ohlcv.columns = pd.MultiIndex.from_product([[asset, ],
+            ohlcv.columns = pd.MultiIndex.from_product([[symbol, ],
                                                         ohlcv.columns])
 
             df = pd.concat([df, ohlcv], axis=1)


### PR DESCRIPTION
fixes crash on not being able to find asset-values in prices. compare **zipline/data/data_portal_live.py:122**, it tries to get prices[asset.symbol], but ibbroker returns data indexed by the whole object (asset) instead of the string-representation of symbol