### PR TITLE
feature:: alpaca bundle now supports different universes.

### DIFF
--- a/etc/requirements.in
+++ b/etc/requirements.in
@@ -72,3 +72,4 @@ bcolz==1.2.1
 # v 3.0+ leads to: ERROR: Could not build wheels for h5py which use PEP 517 and cannot be installed directly. specify
 # exact version
 h5py==2.10.0
+html5lib==1.1

--- a/zipline/data/bundles/alpaca_api.py
+++ b/zipline/data/bundles/alpaca_api.py
@@ -1,5 +1,4 @@
 import collections
-
 import alpaca_trade_api as tradeapi
 from datetime import datetime, timedelta, time as dtime
 import numpy as np
@@ -14,7 +13,10 @@ from dateutil import tz
 from trading_calendars import TradingCalendar
 import yaml
 from zipline.data.bundles import core as bundles
+from zipline.data.bundles.universe import Universe, all_alpaca_assets, get_sp500, get_sp100, get_nasdaq100
 from dateutil.parser import parse as date_parse
+
+
 user_home = str(Path.home())
 custom_data_path = join(user_home, '.zipline/custom_data')
 
@@ -35,10 +37,23 @@ def initialize_client():
 
 ASSETS = None
 def list_assets():
+    with open("alpaca.yaml", mode='r') as f:
+        o = yaml.safe_load(f)
+        try:
+            universe = Universe[o["universe"]]
+        except:
+            universe = Universe.ALL
     global ASSETS
     if not ASSETS:
-        ASSETS = [_.symbol for _ in CLIENT.list_assets()]
-        # ASSETS = [_.ticker for _ in CLIENT.polygon.all_tickers()]
+        if universe == Universe.ALL:
+            ASSETS = all_alpaca_assets(CLIENT)
+        elif universe == Universe.SP100:
+            ASSETS = get_sp100()
+        elif universe == Universe.SP500:
+            ASSETS = get_sp500()
+        elif universe == Universe.NASDAQ100:
+            ASSETS = get_nasdaq100()
+
 
     return list(set(ASSETS))
     # return ['AAPL', 'AA', 'TSLA', 'GOOG', 'MSFT']

--- a/zipline/data/bundles/universe.py
+++ b/zipline/data/bundles/universe.py
@@ -1,0 +1,42 @@
+from enum import Enum
+import pandas as pd
+
+
+class Universe(Enum):
+    ALL = "ALL"
+    SP100 = "S&P 500"
+    SP500 = "S&P 500"
+    NASDAQ100 = "NASDAQ 100"
+
+
+def all_alpaca_assets(client):
+    return [_.symbol for _ in client.list_assets()]
+
+
+def get_sp500():
+    table = pd.read_html('https://en.wikipedia.org/wiki/List_of_S%26P_500_companies')
+    df = table[0]
+    df.columns = df.iloc[0]
+    df = df.iloc[1:]
+    return df.Symbol
+
+
+def get_sp100():
+    table = pd.read_html('https://en.wikipedia.org/wiki/S%26P_100')
+    df = table[2]
+    df.columns = df.iloc[0]
+    df = df.iloc[1:]
+    return df.Symbol
+
+
+def get_nasdaq100():
+    table = pd.read_html('https://en.wikipedia.org/wiki/NASDAQ-100')
+    df = table[3]
+    df.columns = df.iloc[0]
+    df = df.iloc[1:]
+    return df.Ticker
+
+
+if __name__ == '__main__':
+    print(get_sp100()[:10])
+    # print(get_sp500()[:10])


### PR DESCRIPTION
now users can select the universe they work with. 

```py

class Universe(Enum):
    ALL = "ALL"
    SP100 = "S&P 500"
    SP500 = "S&P 500"
    NASDAQ100 = "NASDAQ 100"

```

one could achieve that by indicating that in the `alpaca.yaml` file, like so:

```yaml
key_id: "<YOUR-KEY>"
secret: "<YOUR-SECRET>"
base_url: https://paper-api.alpaca.markets
universe: NASDAQ100
```