### PR TITLE
Custom asset list for alpaca data bundle

### DIFF
--- a/docs/source/alpaca-bundle-ingestion.rst
+++ b/docs/source/alpaca-bundle-ingestion.rst
@@ -58,8 +58,9 @@ How To Use It
   ..
 
   Please note that:
+
   * The assets must be all caps
-  * separated by comma
+  * separated by commas
   * if ``custom_asset_list`` is specified then ``universe`` is ignored if present.
 
 * you need to define your ZIPLINE_ROOT in an environment variable (This is where the

--- a/docs/source/alpaca-bundle-ingestion.rst
+++ b/docs/source/alpaca-bundle-ingestion.rst
@@ -32,6 +32,7 @@ How To Use It
     base_url: https://paper-api.alpaca.markets
     universe: SP500
   ..
+
 * Selecting your universe - which means: what stocks should be included in the ingested DB. The smaller the universe,
   the faster the ingestion is. Selecting the universe is completely up to you, but I do suggest to start small when
   learning how to use the platform. Supported universes:
@@ -44,6 +45,22 @@ How To Use It
         SP500 = "S&P 500"
         NASDAQ100 = "NASDAQ 100"
   ..
+
+* Alternatively you could specify a custom asset list inside the ``alpaca.yaml`` file if, for instance you want to ingest a small number of assets.
+  You do this
+
+  .. code-block:: yaml
+
+    key_id: "<YOUR-KEY>"
+    secret: "<YOUR-SECRET>"
+    base_url: https://paper-api.alpaca.markets
+    custom_asset_list: AAPL, TSLA, GOOG
+  ..
+
+  Please note that:
+  * The assets must be all caps
+  * separated by comma
+  * if ``custom_asset_list`` is specified then ``universe`` is ignored if present.
 
 * you need to define your ZIPLINE_ROOT in an environment variable (This is where the
   ingested data will be stored). You need this env variable in for every zipline related script you execute (that

--- a/zipline/data/bundles/alpaca_api.py
+++ b/zipline/data/bundles/alpaca_api.py
@@ -357,4 +357,4 @@ if __name__ == '__main__':
         show_progress=True,
     )
 
-    print("--- %s seconds ---" % (time.time() - start_time))
+    print(f"--- It took {timedelta(seconds=time.time() - start_time)} ---")

--- a/zipline/data/bundles/alpaca_api.py
+++ b/zipline/data/bundles/alpaca_api.py
@@ -41,20 +41,24 @@ def list_assets():
     if not ASSETS:
         with open("alpaca.yaml", mode='r') as f:
             o = yaml.safe_load(f)
-            try:
-                universe = Universe[o["universe"]]
-            except:
-                universe = Universe.ALL
-        if not ASSETS:
-            if universe == Universe.ALL:
-                ASSETS = all_alpaca_assets(CLIENT)
-            elif universe == Universe.SP100:
-                ASSETS = get_sp100()
-            elif universe == Universe.SP500:
-                ASSETS = get_sp500()
-            elif universe == Universe.NASDAQ100:
-                ASSETS = get_nasdaq100()
-        ASSETS = list(set(ASSETS))
+            custom_asset_list = o.get("custom_asset_list")
+            if custom_asset_list:
+                custom_asset_list = custom_asset_list.strip().replace(" ", "").split(",")
+                ASSETS = list(set(custom_asset_list))
+            else:
+                try:
+                    universe = Universe[o["universe"]]
+                except:
+                    universe = Universe.ALL
+                if universe == Universe.ALL:
+                    ASSETS = all_alpaca_assets(CLIENT)
+                elif universe == Universe.SP100:
+                    ASSETS = get_sp100()
+                elif universe == Universe.SP500:
+                    ASSETS = get_sp500()
+                elif universe == Universe.NASDAQ100:
+                    ASSETS = get_nasdaq100()
+                ASSETS = list(set(ASSETS))
     return ASSETS
     # return ['AAPL', 'AA', 'TSLA', 'GOOG', 'MSFT']
 

--- a/zipline/data/bundles/alpaca_api.py
+++ b/zipline/data/bundles/alpaca_api.py
@@ -37,25 +37,25 @@ def initialize_client():
 
 ASSETS = None
 def list_assets():
-    with open("alpaca.yaml", mode='r') as f:
-        o = yaml.safe_load(f)
-        try:
-            universe = Universe[o["universe"]]
-        except:
-            universe = Universe.ALL
     global ASSETS
     if not ASSETS:
-        if universe == Universe.ALL:
-            ASSETS = all_alpaca_assets(CLIENT)
-        elif universe == Universe.SP100:
-            ASSETS = get_sp100()
-        elif universe == Universe.SP500:
-            ASSETS = get_sp500()
-        elif universe == Universe.NASDAQ100:
-            ASSETS = get_nasdaq100()
-
-
-    return list(set(ASSETS))
+        with open("alpaca.yaml", mode='r') as f:
+            o = yaml.safe_load(f)
+            try:
+                universe = Universe[o["universe"]]
+            except:
+                universe = Universe.ALL
+        if not ASSETS:
+            if universe == Universe.ALL:
+                ASSETS = all_alpaca_assets(CLIENT)
+            elif universe == Universe.SP100:
+                ASSETS = get_sp100()
+            elif universe == Universe.SP500:
+                ASSETS = get_sp500()
+            elif universe == Universe.NASDAQ100:
+                ASSETS = get_nasdaq100()
+        ASSETS = list(set(ASSETS))
+    return ASSETS
     # return ['AAPL', 'AA', 'TSLA', 'GOOG', 'MSFT']
 
 


### PR DESCRIPTION
Added ability to specify a custom asset list for alpaca data bundle.
could be used for fast iterations for dev or a small universe 

do it by specifying `custom_asset_list` in `alpaca.yaml`

read the docs for more details. 
