### PR TITLE
Add upgrade to Dockerfile to fix broken root certs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ ENV PROJECT_DIR=/projects \
 
 RUN mkdir ${PROJECT_DIR} \
     && apt-get -y update \
+    && apt-get -y upgrade \
     && apt-get -y install libfreetype6-dev libpng-dev libopenblas-dev liblapack-dev gfortran libhdf5-dev \
     && curl -L https://downloads.sourceforge.net/project/ta-lib/ta-lib/0.4.0/ta-lib-0.4.0-src.tar.gz | tar xvz
 


### PR DESCRIPTION
Because the python image is so old, the root cert is too old and therefore it isnt possible to use ssl:
![Bildschirmfoto von 2021-10-28 11-58-21](https://user-images.githubusercontent.com/12197109/139536853-c6e6a230-5c25-48ae-a3dd-4f6e5101bfaf.png)
To fix this we can add "apt upgrade" to the Dockerfile
